### PR TITLE
fix label in "SD Card" tab

### DIFF
--- a/src/template-parts/tabs/tab-sd-card.html
+++ b/src/template-parts/tabs/tab-sd-card.html
@@ -1,14 +1,14 @@
 <div data-tab="SD Card" class="tabs-body__item">
     <div id="sd-card" class="form">
-        
+
         <div class="form-group row">
             <div class="text-content">
                 <p>
-                    Get the type of connected nodes via serial
+                    Get the microSD card filesystem statistics
                 </p>
             </div>
         </div>
-        
+
         <div class="form-group row">
             <div class="input-wrap active">
                 <label for="sdTotal" class="label">Total:</label>
@@ -16,7 +16,7 @@
                 <div class="prefix-label">B</div>
             </div>
         </div>
-        
+
         <div class="form-group row">
             <div class="input-wrap active">
                 <label for="sdUse" class="label">Used:</label>
@@ -24,7 +24,7 @@
                 <div class="prefix-label">B</div>
             </div>
         </div>
-        
+
         <div class="form-group row">
             <div class="input-wrap active">
                 <label for="sdFree" class="label">Free:</label>
@@ -32,9 +32,7 @@
                 <div class="prefix-label">B</div>
             </div>
         </div>
-        
-     
-    
+
     </div>
 </div>
 


### PR DESCRIPTION
The label in "SD Card" is copied from "Node Info". Fixed this but did not rebuild dist because unsure how it's done correctly (is it just `npm run build`?)