### PR TITLE
feat: mobile navigation menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "bmc-ui",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "bmc-ui",
-            "version": "3.1.0",
+            "version": "3.1.1",
             "dependencies": {
                 "@fontsource/inter": "^5.0.18",
                 "@radix-ui/react-checkbox": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bmc-ui",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "private": true,
     "type": "module",
     "scripts": {

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,0 +1,81 @@
+import { MenuIcon } from "lucide-react";
+import { XIcon } from "lucide-react";
+import { useState } from "react";
+
+import Logo from "@/assets/logo-light.svg?react";
+import BasicInfo from "@/components/BasicInfo";
+import ThemeToggle from "@/components/theme-toggle";
+import { Button } from "@/components/ui/button";
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import { useMediaQuery } from "@/hooks/use-media-query";
+
+import NavigationLinks from "./navigation-links";
+
+export default function Header() {
+  const isDesktop = useMediaQuery("(min-width: 768px)");
+  const [isOpen, setIsOpen] = useState(false);
+
+  if (isDesktop)
+    return (
+      <header className="flex w-full items-center justify-between px-5 py-8 xl:w-[75rem] xl:px-0">
+        <div className="flex items-center">
+          <Logo className="mr-4 size-16 dark:fill-neutral-100" />
+          <BasicInfo />
+        </div>
+        <ThemeToggle />
+      </header>
+    );
+
+  return (
+    <header className="flex w-full items-center justify-between p-4 xl:w-[75rem] xl:px-0">
+      <div className="flex items-center">
+        <Logo className="mr-4 size-12 dark:fill-neutral-100" />
+        <p className="text-xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-100">
+          Turing Pi
+        </p>
+      </div>
+      <Button
+        variant="bwSquare"
+        size="icon"
+        className="md:hidden"
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        <MenuIcon />
+      </Button>
+      <Drawer
+        direction="right"
+        open={!isDesktop && isOpen}
+        onOpenChange={(open) => setIsOpen(open)}
+      >
+        <DrawerContent className="h-full" direction="right">
+          <DrawerHeader className="text-left">
+            <DrawerTitle className="mb-4 mt-1 flex items-center justify-between">
+              <span className="text-xl text-neutral-900 dark:text-neutral-200">
+                Navigation
+              </span>
+              <DrawerClose asChild>
+                <Button type="button" variant="bwSquare" size="icon">
+                  <XIcon />
+                </Button>
+              </DrawerClose>
+            </DrawerTitle>
+            <NavigationLinks
+              isDesktop={isDesktop}
+              onClick={() => setIsOpen(false)}
+            />
+          </DrawerHeader>
+          <DrawerFooter className="items-end">
+            <ThemeToggle />
+          </DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+    </header>
+  );
+}

--- a/src/components/navigation-links.tsx
+++ b/src/components/navigation-links.tsx
@@ -1,0 +1,85 @@
+import { Link, type LinkProps } from "@tanstack/react-router";
+import { ArrowRightIcon } from "lucide-react";
+import { type ReactNode, useMemo } from "react";
+
+const navigationLinks = [
+  { to: "/info", label: "Info" },
+  { to: "/nodes", label: "Nodes" },
+  { to: "/usb", label: "USB" },
+  { to: "/firmware-upgrade", label: "Firmware Upgrade" },
+  { to: "/flash-node", label: "Flash Node" },
+  { to: "/about", label: "About" },
+] as const;
+
+function MobileLink({
+  to,
+  children,
+  onClick,
+}: LinkProps & { onClick?: () => void; children: ReactNode }) {
+  return (
+    <Link
+      to={to}
+      className="mx-2 flex items-center justify-between text-lg font-medium text-neutral-500 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-200"
+      activeProps={{
+        className: "text-neutral-900 dark:text-neutral-200",
+      }}
+      onClick={onClick}
+    >
+      {children}
+      <ArrowRightIcon />
+    </Link>
+  );
+}
+
+function TabLink({ to, children }: LinkProps) {
+  return (
+    <Link
+      to={to}
+      viewTransition
+      className="w-full py-3.5 text-center text-base font-semibold hover:bg-white dark:hover:bg-neutral-800"
+      activeProps={{
+        className:
+          "border-t-2 border-neutral-300 bg-white outline-none dark:border-neutral-700 dark:bg-neutral-900 hover:bg-white dark:hover:bg-neutral-900",
+      }}
+    >
+      {children}
+    </Link>
+  );
+}
+
+export default function NavigationLinks({
+  isDesktop,
+  onClick,
+}: {
+  isDesktop: boolean;
+  onClick?: () => void;
+}) {
+  const renderLinks = useMemo(
+    () =>
+      navigationLinks.map(({ to, label }) => (
+        <TabLink key={to} to={to}>
+          {label}
+        </TabLink>
+      )),
+    []
+  );
+
+  const renderMobileLinks = useMemo(
+    () =>
+      navigationLinks.map(({ to, label }) => (
+        <MobileLink key={to} to={to} onClick={onClick}>
+          {label}
+        </MobileLink>
+      )),
+    []
+  );
+
+  if (isDesktop)
+    return (
+      <nav className="hidden justify-around bg-turing-bg dark:bg-turing-bg-dark md:flex">
+        {renderLinks}
+      </nav>
+    );
+
+  return <nav className="flex flex-col gap-5">{renderMobileLinks}</nav>;
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -13,6 +13,8 @@ const buttonVariants = cva(
         "turing-green":
           "border-black bg-turing-btn fill-neutral-900 text-neutral-900 hover:bg-turing-btn-hover",
         bw: "border-black bg-white fill-neutral-900 hover:bg-black hover:text-white dark:border-white dark:bg-black dark:fill-white dark:text-white dark:hover:bg-white dark:hover:text-black",
+        bwSquare:
+          "rounded-lg border-black bg-white fill-neutral-900 hover:bg-black hover:text-white dark:border-white dark:bg-black dark:fill-white dark:text-white dark:hover:bg-white dark:hover:text-black",
         destructive:
           "border-red-700 bg-red-50 text-red-700 hover:bg-red-700 hover:text-neutral-100 dark:border-red-100 dark:bg-red-700 dark:text-neutral-100 dark:hover:bg-red-100 dark:hover:text-red-700",
       },

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -34,19 +34,25 @@ DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName;
 
 const DrawerContent = forwardRef<
   React.ElementRef<typeof DrawerPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content> & {
+    direction?: "top" | "bottom" | "left" | "right";
+  }
+>(({ className, direction = "bottom", children, ...props }, ref) => (
   <DrawerPortal>
     <DrawerOverlay />
     <DrawerPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-xl border border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-950",
+        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col border border-neutral-200 bg-white focus:outline-none dark:border-neutral-800 dark:bg-neutral-950",
+        direction === "right" && "rounded-none",
+        direction === "bottom" && "rounded-t-xl",
         className
       )}
       {...props}
     >
-      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-neutral-100 dark:bg-neutral-900" />
+      {direction === "bottom" && (
+        <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-neutral-100 dark:bg-neutral-900" />
+      )}
       {children}
     </DrawerPrimitive.Content>
   </DrawerPortal>
@@ -58,7 +64,10 @@ const DrawerHeader = ({
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
-    className={cn("grid gap-1.5 p-4 text-center sm:text-left", className)}
+    className={cn(
+      "flex flex-col overflow-y-scroll overflow-x-hidden gap-1.5 p-4 text-center sm:text-left",
+      className
+    )}
     {...props}
   />
 );

--- a/src/routes/_tabLayout.tsx
+++ b/src/routes/_tabLayout.tsx
@@ -1,14 +1,7 @@
-import {
-  createFileRoute,
-  Link,
-  type LinkProps,
-  Outlet,
-  redirect,
-} from "@tanstack/react-router";
+import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
 
-import Logo from "@/assets/logo-light.svg?react";
-import BasicInfo from "@/components/BasicInfo";
-import ThemeToggle from "@/components/theme-toggle";
+import Header from "@/components/header";
+import NavigationLinks from "@/components/navigation-links";
 
 export const Route = createFileRoute("/_tabLayout")({
   beforeLoad: ({ context, location }) => {
@@ -25,42 +18,13 @@ export const Route = createFileRoute("/_tabLayout")({
   component: AppLayoutComponent,
 });
 
-function TabLink({ to, children }: LinkProps) {
-  return (
-    <Link
-      to={to}
-      viewTransition
-      className="w-full py-3.5 text-center text-base font-semibold hover:bg-white dark:hover:bg-neutral-800"
-      activeProps={{
-        className:
-          "border-t-2 border-neutral-300 bg-white outline-none dark:border-neutral-700 dark:bg-neutral-900 hover:bg-white dark:hover:bg-neutral-900",
-      }}
-    >
-      {children}
-    </Link>
-  );
-}
-
 function AppLayoutComponent() {
   return (
     <div className="flex w-full flex-col items-center justify-center">
-      <header className="flex w-full items-center justify-between px-5 py-8 xl:w-[75rem] xl:px-0">
-        <div className="flex items-center">
-          <Logo className="mr-4 size-16 dark:fill-neutral-100" />
-          <BasicInfo />
-        </div>
-        <ThemeToggle />
-      </header>
+      <Header />
 
       <main className="w-full overflow-hidden border border-neutral-300 bg-white shadow dark:border-neutral-700 dark:bg-neutral-900 xl:w-[75rem]">
-        <nav className="flex justify-around bg-turing-bg dark:bg-turing-bg-dark">
-          <TabLink to="/info">Info</TabLink>
-          <TabLink to="/nodes">Nodes</TabLink>
-          <TabLink to="/usb">USB</TabLink>
-          <TabLink to="/firmware-upgrade">Firmware Upgrade</TabLink>
-          <TabLink to="/flash-node">Flash Node</TabLink>
-          <TabLink to="/about">About</TabLink>
-        </nav>
+        <NavigationLinks isDesktop />
         <div className="px-3 py-6 md:p-12">
           <Outlet />
         </div>


### PR DESCRIPTION
I'm adding a new navigation menu that renders only on small viewports (mobile phones). It allows the view to use more screen real estate while delivering a navigation experience the user would expect from a mobile site.

The tabs experience remains the same for tablets & bigger devices.



<details>
  <summary>Quick video</summary>

 
  <video src='https://github.com/turing-machines/BMC-UI/assets/11593618/2e78b646-1ff9-4364-b1cf-f4b8f6d3e926' />

</details>

Bumped the version to `3.1.1` as in the big scheme of things, I've considered this a patch for the mobile navigation rather than a new feature