### PR TITLE
fix: flashing to continue on navigation changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "bmc-ui",
-    "version": "3.1.1",
+    "version": "3.1.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "bmc-ui",
-            "version": "3.1.1",
+            "version": "3.1.2",
             "dependencies": {
                 "@fontsource/inter": "^5.0.18",
                 "@radix-ui/react-checkbox": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bmc-ui",
-    "version": "3.1.1",
+    "version": "3.1.2",
     "private": true,
     "type": "module",
     "scripts": {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -6,6 +6,7 @@ import ReactDOM from "react-dom/client";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { AuthProvider } from "@/contexts/AuthContext";
+import { FlashProvider } from "@/contexts/FlashContext";
 import InnerApp from "@/innerApp";
 import { type router } from "@/router";
 
@@ -27,10 +28,12 @@ if (!rootElement.innerHTML) {
       <ThemeProvider attribute="class">
         <AuthProvider>
           <QueryClientProvider client={queryClient}>
-            <TooltipProvider delayDuration={0}>
-              <InnerApp />
-              <Toaster />
-            </TooltipProvider>
+            <FlashProvider>
+              <TooltipProvider delayDuration={0}>
+                <InnerApp />
+                <Toaster />
+              </TooltipProvider>
+            </FlashProvider>
           </QueryClientProvider>
         </AuthProvider>
       </ThemeProvider>

--- a/src/components/navigation-links.tsx
+++ b/src/components/navigation-links.tsx
@@ -2,6 +2,9 @@ import { Link, type LinkProps } from "@tanstack/react-router";
 import { ArrowRightIcon } from "lucide-react";
 import { type ReactNode, useMemo } from "react";
 
+import { useFlash } from "@/hooks/use-flash";
+import { cn } from "@/lib/utils";
+
 const navigationLinks = [
   { to: "/info", label: "Info" },
   { to: "/nodes", label: "Nodes" },
@@ -11,15 +14,24 @@ const navigationLinks = [
   { to: "/about", label: "About" },
 ] as const;
 
+interface FlashingLinkProps {
+  isFlashing: boolean;
+}
+
 function MobileLink({
   to,
   children,
   onClick,
-}: LinkProps & { onClick?: () => void; children: ReactNode }) {
+  isFlashing,
+}: LinkProps &
+  FlashingLinkProps & { onClick?: () => void; children: ReactNode }) {
   return (
     <Link
       to={to}
-      className="mx-2 flex items-center justify-between text-lg font-medium text-neutral-500 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-200"
+      className={cn(
+        "mx-2 flex items-center justify-between text-lg font-medium text-neutral-500 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-200",
+        isFlashing && "animate-pulse duration-700"
+      )}
       activeProps={{
         className: "text-neutral-900 dark:text-neutral-200",
       }}
@@ -31,12 +43,15 @@ function MobileLink({
   );
 }
 
-function TabLink({ to, children }: LinkProps) {
+function TabLink({ to, children, isFlashing }: LinkProps & FlashingLinkProps) {
   return (
     <Link
       to={to}
       viewTransition
-      className="w-full py-3.5 text-center text-base font-semibold hover:bg-white dark:hover:bg-neutral-800"
+      className={cn(
+        "w-full py-3.5 text-center text-base font-semibold hover:bg-white dark:hover:bg-neutral-800",
+        isFlashing && "animate-pulse duration-700"
+      )}
       activeProps={{
         className:
           "border-t-2 border-neutral-300 bg-white outline-none dark:border-neutral-700 dark:bg-neutral-900 hover:bg-white dark:hover:bg-neutral-900",
@@ -54,24 +69,49 @@ export default function NavigationLinks({
   isDesktop: boolean;
   onClick?: () => void;
 }) {
+  const { flashType, isFlashing } = useFlash();
+
   const renderLinks = useMemo(
     () =>
-      navigationLinks.map(({ to, label }) => (
-        <TabLink key={to} to={to}>
-          {label}
-        </TabLink>
-      )),
-    []
+      navigationLinks.map(({ to, label }) => {
+        const isNodeFlashing =
+          isFlashing && flashType === "node" && to === "/flash-node";
+        const isFirmwareFlashing =
+          isFlashing && flashType === "firmware" && to === "/firmware-upgrade";
+
+        return (
+          <TabLink
+            key={to}
+            to={to}
+            isFlashing={isNodeFlashing || isFirmwareFlashing}
+          >
+            {label}
+          </TabLink>
+        );
+      }),
+    [isFlashing, flashType]
   );
 
   const renderMobileLinks = useMemo(
     () =>
-      navigationLinks.map(({ to, label }) => (
-        <MobileLink key={to} to={to} onClick={onClick}>
-          {label}
-        </MobileLink>
-      )),
-    []
+      navigationLinks.map(({ to, label }) => {
+        const isNodeFlashing =
+          isFlashing && flashType === "node" && to === "/flash-node";
+        const isFirmwareFlashing =
+          isFlashing && flashType === "firmware" && to === "/firmware-upgrade";
+
+        return (
+          <MobileLink
+            key={to}
+            to={to}
+            onClick={onClick}
+            isFlashing={isNodeFlashing || isFirmwareFlashing}
+          >
+            {label}
+          </MobileLink>
+        );
+      }),
+    [isFlashing, flashType, onClick]
   );
 
   if (isDesktop)

--- a/src/contexts/FlashContext.tsx
+++ b/src/contexts/FlashContext.tsx
@@ -1,0 +1,274 @@
+import { type AxiosProgressEvent } from "axios";
+import { filesize } from "filesize";
+import React, {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useState,
+} from "react";
+
+import RebootModal from "@/components/RebootModal";
+import { toast } from "@/hooks/use-toast";
+import {
+  useFirmwareUpdateMutation,
+  useNodeUpdateMutation,
+} from "@/lib/api/file";
+import {
+  type FlashStatus,
+  useFirmwareStatusQuery,
+  useFlashStatusQuery,
+} from "@/lib/api/get";
+import { useRebootBMCMutation } from "@/lib/api/set";
+
+type FlashType = "firmware" | "node" | null;
+
+interface FlashContextValue {
+  flashType: FlashType;
+  setFlashType: React.Dispatch<React.SetStateAction<FlashType>>;
+  isFlashing: boolean;
+  statusMessage: string;
+  firmwareUpdateMutation: ReturnType<typeof useFirmwareUpdateMutation>;
+  nodeUpdateMutation: ReturnType<typeof useNodeUpdateMutation>;
+  firmwareStatus: ReturnType<typeof useFirmwareStatusQuery>;
+  flashStatus: ReturnType<typeof useFlashStatusQuery>;
+  uploadProgress?: { transferred: string; total: string | null; pct: number };
+  handleFirmwareUpload: (variables: {
+    file?: File;
+    url?: string;
+    sha256?: string;
+  }) => Promise<void>;
+  handleNodeUpdate: (variables: {
+    nodeId: number;
+    file?: File;
+    url?: string;
+    sha256?: string;
+    skipCRC: boolean;
+  }) => Promise<void>;
+}
+
+export const FlashContext = createContext<FlashContextValue | null>(null);
+
+interface FlashProviderProps {
+  children: ReactNode;
+}
+
+export const FlashProvider: React.FC<FlashProviderProps> = ({ children }) => {
+  const [flashType, setFlashType] = useState<FlashType>(null);
+  const [isUploading, setIsUploading] = useState(false);
+  const [isFlashing, setIsFlashing] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string>("");
+  const [rebootModalOpened, setRebootModalOpened] = useState(false);
+  const { mutate: mutateRebootBMC } = useRebootBMCMutation();
+  const [uploadProgress, setUploadProgress] =
+    useState<FlashContextValue["uploadProgress"]>();
+
+  const uploadProgressCallback = useCallback(
+    (progressEvent: AxiosProgressEvent) => {
+      setUploadProgress({
+        transferred: filesize(progressEvent.loaded ?? 0, { standard: "jedec" }),
+        total: progressEvent.total
+          ? filesize(progressEvent.total, { standard: "jedec" })
+          : null,
+        pct: progressEvent.total
+          ? Math.round((progressEvent.loaded / progressEvent.total) * 100)
+          : 100,
+      });
+    },
+    []
+  );
+
+  const firmwareUpdateMutation = useFirmwareUpdateMutation(
+    uploadProgressCallback
+  );
+  const nodeUpdateMutation = useNodeUpdateMutation(uploadProgressCallback);
+  const firmwareStatus = useFirmwareStatusQuery(
+    flashType === "firmware" && isFlashing
+  );
+  const flashStatus = useFlashStatusQuery(flashType === "node" && isFlashing);
+
+  const handleRebootBMC = () => {
+    setRebootModalOpened(false);
+    mutateRebootBMC(undefined, {
+      onSuccess: () => {
+        toast({ title: "Rebooting BMC", description: "The BMC is rebooting" });
+      },
+      onError: (error) => {
+        toast({
+          title: "Failed to reboot BMC",
+          description: error.message,
+          variant: "destructive",
+        });
+      },
+    });
+  };
+
+  const handleFirmwareUpload = async (variables: {
+    file?: File;
+    url?: string;
+    sha256?: string;
+  }) => {
+    setFlashType("firmware");
+    setIsUploading(true);
+    setStatusMessage("Uploading BMC firmware...");
+    await firmwareUpdateMutation.mutateAsync(variables, {
+      onSuccess: () => {
+        setIsUploading(false);
+        setIsFlashing(true);
+        setStatusMessage("Writing firmware to BMC...");
+        void firmwareStatus.refetch();
+      },
+      onError: (error) => {
+        setIsUploading(false);
+        const msg = "Failed to upload the BMC firmware";
+        setStatusMessage(msg);
+        toast({
+          title: msg,
+          description: error.message,
+          variant: "destructive",
+        });
+      },
+    });
+  };
+
+  const handleNodeUpdate = async (variables: {
+    nodeId: number;
+    file?: File;
+    url?: string;
+    sha256?: string;
+    skipCRC: boolean;
+  }) => {
+    setFlashType("node");
+    setIsUploading(true);
+    setStatusMessage(`Transferring image to node ${variables.nodeId + 1}...`);
+    await nodeUpdateMutation.mutateAsync(variables, {
+      onSuccess: () => {
+        setIsUploading(false);
+        setIsFlashing(true);
+        const msg = variables.skipCRC
+          ? "Transferring image to the node..."
+          : "Checking CRC and transferring image to the node...";
+        setStatusMessage(msg);
+        void flashStatus.refetch();
+      },
+      onError: (error) => {
+        setIsUploading(false);
+        const msg = `Failed to transfer the image to node ${variables.nodeId + 1}`;
+        setStatusMessage(msg);
+        toast({
+          title: msg,
+          description: error.message,
+          variant: "destructive",
+        });
+      },
+    });
+  };
+
+  const handleError = useCallback((error: string, title: string) => {
+    setIsFlashing(false);
+    setUploadProgress(undefined);
+    setStatusMessage(error);
+    toast({
+      title,
+      description: error,
+      variant: "destructive",
+    });
+  }, []);
+
+  const handleTransferProgress = useCallback((data: FlashStatus) => {
+    const bytesWritten = data.Transferring?.bytes_written ?? 0;
+    setUploadProgress({
+      transferred: `${filesize(bytesWritten, { standard: "jedec" })} written`,
+      total: null,
+      pct: 100,
+    });
+  }, []);
+
+  const handleSuccess = useCallback((title: string, message: string) => {
+    setIsFlashing(false);
+    setUploadProgress(undefined);
+    setStatusMessage(message);
+    toast({ title, description: message });
+  }, []);
+
+  useEffect(() => {
+    if (!isFlashing || !flashType) return;
+
+    if (flashType === "node") {
+      if (!flashStatus.isStale) {
+        if (flashStatus.data?.Error) {
+          handleError(flashStatus.data.Error, "An error has occurred");
+        } else if (flashStatus.data?.Transferring) {
+          handleTransferProgress(flashStatus.data);
+        } else if (flashStatus.data?.Done) {
+          handleSuccess(
+            "Flashing successful",
+            "Image flashed successfully to the node"
+          );
+        }
+      }
+    } else if (flashType === "firmware") {
+      if (!firmwareStatus.isStale) {
+        if (firmwareStatus.data?.Error) {
+          handleError(firmwareStatus.data.Error, "An error has occurred");
+        } else if (firmwareStatus.data?.Transferring) {
+          handleTransferProgress(firmwareStatus.data);
+        } else if (firmwareStatus.data?.Done) {
+          handleSuccess(
+            "Flashing successful",
+            "Firmware upgrade completed successfully"
+          );
+          setRebootModalOpened(true);
+        }
+      }
+    }
+  }, [
+    isFlashing,
+    flashType,
+    flashStatus.data,
+    firmwareStatus.data,
+    firmwareStatus.isStale,
+    flashStatus.isStale,
+    handleError,
+    handleTransferProgress,
+    handleSuccess,
+  ]);
+
+  return (
+    <FlashContext.Provider
+      value={{
+        flashType,
+        setFlashType,
+        isFlashing: isUploading || isFlashing,
+        statusMessage,
+        firmwareUpdateMutation,
+        nodeUpdateMutation,
+        firmwareStatus,
+        flashStatus,
+        uploadProgress,
+        handleFirmwareUpload,
+        handleNodeUpdate,
+      }}
+    >
+      <>
+        {children}
+        <RebootModal
+          isOpen={rebootModalOpened}
+          onClose={() => setRebootModalOpened(false)}
+          onReboot={handleRebootBMC}
+          title="Upgrade Finished!"
+          message={
+            <div className="text-neutral-900 opacity-60 dark:text-neutral-100">
+              <p>To finalize the upgrade, a system reboot is necessary.</p>
+              <p>Would you like to proceed with the reboot now?</p>
+              <p className="mt-4 text-xs italic">
+                The nodes will temporarily lose power until the reboot process
+                is complete.
+              </p>
+            </div>
+          }
+        />
+      </>
+    </FlashContext.Provider>
+  );
+};

--- a/src/hooks/use-flash.ts
+++ b/src/hooks/use-flash.ts
@@ -1,0 +1,11 @@
+import { useContext } from "react";
+
+import { FlashContext } from "@/contexts/FlashContext";
+
+export function useFlash() {
+  const context = useContext(FlashContext);
+  if (!context) {
+    throw new Error("useFlash must be used within an FlashProvider");
+  }
+  return context;
+}

--- a/src/lib/api/get.ts
+++ b/src/lib/api/get.ts
@@ -30,7 +30,7 @@ interface AboutTabResponse {
   version: string;
 }
 
-interface FlashStatus {
+export interface FlashStatus {
   Transferring?: {
     id: number;
     process_name: string;
@@ -99,6 +99,7 @@ export function useAboutTabData() {
 
   return useSuspenseQuery({
     queryKey: ["aboutTabData"],
+    staleTime: 1000 * 60 * 60, // Valid for 1 hour
     queryFn: async () => {
       const response = await api.get<APIResponse<AboutTabResponse>>("/bmc", {
         params: {
@@ -153,6 +154,7 @@ export function useFlashStatusQuery(enabled: boolean) {
 
   return useQuery({
     queryKey: ["flashStatus"],
+    staleTime: 1000, // Valid for 1 second
     queryFn: async () => {
       const response = await api.get<FlashStatus>("/bmc", {
         params: {
@@ -172,6 +174,7 @@ export function useFirmwareStatusQuery(enabled: boolean) {
 
   return useQuery({
     queryKey: ["firmwareStatus"],
+    staleTime: 1000, // Valid for 1 second
     queryFn: async () => {
       const response = await api.get<FlashStatus>("/bmc", {
         params: {

--- a/src/routes/_tabLayout/firmware-upgrade.lazy.tsx
+++ b/src/routes/_tabLayout/firmware-upgrade.lazy.tsx
@@ -1,87 +1,40 @@
 import { createLazyFileRoute } from "@tanstack/react-router";
-import type { AxiosProgressEvent } from "axios";
-import { filesize } from "filesize";
 import { useEffect, useRef, useState } from "react";
 
 import ConfirmationModal from "@/components/ConfirmationModal";
-import RebootModal from "@/components/RebootModal";
 import TabView from "@/components/TabView";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Progress } from "@/components/ui/progress";
-import { useToast } from "@/hooks/use-toast";
-import { useFirmwareUpdateMutation } from "@/lib/api/file";
-import { useFirmwareStatusQuery } from "@/lib/api/get";
-import { useRebootBMCMutation } from "@/lib/api/set";
+import { useFlash } from "@/hooks/use-flash";
 
 export const Route = createLazyFileRoute("/_tabLayout/firmware-upgrade")({
   component: FirmwareUpgrade,
 });
 
 function FirmwareUpgrade() {
-  const { toast } = useToast();
   const formRef = useRef<HTMLFormElement>(null);
-  const [isUpgrading, setIsUpgrading] = useState(false);
   const [statusMessage, setStatusMessage] = useState("");
   const [confirmFlashModal, setConfirmFlashModal] = useState(false);
-  const [rebootModalOpened, setRebootModalOpened] = useState(false);
-  const [progress, setProgress] = useState<{
-    transferred: string;
-    total?: string;
-    pct: number;
-  }>({ transferred: "", total: "", pct: 0 });
-  const uploadProgressCallback = (progressEvent: AxiosProgressEvent) => {
-    setProgress({
-      transferred: filesize(progressEvent.loaded ?? 0, { standard: "jedec" }),
-      total: filesize(progressEvent.total ?? 0, { standard: "jedec" }),
-      pct: Math.round(
-        ((progressEvent.loaded ?? 0) / (progressEvent.total ?? 1)) * 100
-      ),
-    });
-  };
   const {
-    mutate: mutateFirmwareUpdate,
-    isIdle,
-    isPending,
-  } = useFirmwareUpdateMutation(uploadProgressCallback);
-  const { mutate: mutateRebootBMC } = useRebootBMCMutation();
-  const { data, refetch } = useFirmwareStatusQuery(isUpgrading);
+    flashType,
+    isFlashing,
+    statusMessage: _statusMessage,
+    firmwareUpdateMutation,
+    uploadProgress,
+    handleFirmwareUpload,
+  } = useFlash();
 
   useEffect(() => {
-    if (isUpgrading && data?.Error) {
-      setStatusMessage(data.Error);
-      toast({
-        title: "An error has occurred",
-        description: data.Error,
-        variant: "destructive",
-      });
-      setIsUpgrading(false);
-    } else if (!isUpgrading && data?.Transferring) {
-      setIsUpgrading(true);
-      setStatusMessage("Writing firmware to BMC...");
-
-      // Update progress bar using bytes_written from Transferring data
-      const bytesWritten = data.Transferring.bytes_written ?? 0;
-      setProgress({
-        transferred: `${filesize(bytesWritten, { standard: "jedec" })} written`,
-        total: undefined,
-        pct: 100,
-      });
-    } else if (isUpgrading && data?.Done) {
-      setIsUpgrading(false);
-      const msg = "Firmware upgrade completed successfully";
-      setStatusMessage(msg);
-      toast({ title: "Upgrade successful", description: msg });
-      setRebootModalOpened(true);
-    }
-  }, [data]);
+    _statusMessage && setStatusMessage(_statusMessage);
+  }, [_statusMessage]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setConfirmFlashModal(true);
   };
 
-  const handleFirmwareUpload = () => {
+  const handleUpload = () => {
     if (formRef.current) {
       setConfirmFlashModal(false);
 
@@ -93,41 +46,8 @@ function FirmwareUpgrade() {
       const sha256 = (form.elements.namedItem("sha256") as HTMLInputElement)
         .value;
 
-      setStatusMessage("Uploading BMC firmware...");
-      mutateFirmwareUpdate(
-        { file, url, sha256 },
-        {
-          onSuccess: () => {
-            void refetch();
-          },
-          onError: (e) => {
-            const msg = "Upgrade failed";
-            setStatusMessage(msg);
-            toast({
-              title: msg,
-              description: e.message,
-              variant: "destructive",
-            });
-          },
-        }
-      );
+      void handleFirmwareUpload({ file, url, sha256 });
     }
-  };
-
-  const handleRebootBMC = () => {
-    setRebootModalOpened(false);
-    mutateRebootBMC(undefined, {
-      onSuccess: () => {
-        toast({ title: "Rebooting BMC", description: "The BMC is rebooting" });
-      },
-      onError: (e) => {
-        toast({
-          title: "Failed to reboot BMC",
-          description: e.message,
-          variant: "destructive",
-        });
-      },
-    });
   };
 
   return (
@@ -147,47 +67,36 @@ function FirmwareUpgrade() {
         <div>
           <Button
             type="submit"
-            disabled={isPending || isUpgrading}
-            isLoading={isPending || isUpgrading}
+            disabled={firmwareUpdateMutation.isPending || isFlashing}
+            isLoading={
+              firmwareUpdateMutation.isPending ||
+              (isFlashing && flashType === "firmware")
+            }
           >
             Upgrade
           </Button>
         </div>
-        {!isIdle && (
-          <div className="mt-4 block">
-            <Progress
-              aria-label="Firmware upgrade progress"
-              value={progress.pct}
-              label={`${progress.transferred}${progress.total ? ` / ${progress.total}` : ""}`}
-              pulsing={isPending || isUpgrading}
-            />
-            <div className="mt-2 text-sm">{statusMessage}</div>
-          </div>
+        {uploadProgress && flashType === "firmware" && (
+          <Progress
+            aria-label="Firmware upgrade progress"
+            className="mt-4"
+            value={uploadProgress.pct}
+            label={`${uploadProgress.transferred}${
+              uploadProgress.total ? ` / ${uploadProgress.total}` : ""
+            }`}
+            pulsing={firmwareUpdateMutation.isPending || isFlashing}
+          />
+        )}
+        {flashType === "firmware" && statusMessage && (
+          <div className="mt-4 text-sm">{statusMessage}</div>
         )}
       </form>
       <ConfirmationModal
         isOpen={confirmFlashModal}
         onClose={() => setConfirmFlashModal(false)}
-        onConfirm={handleFirmwareUpload}
+        onConfirm={handleUpload}
         title="Upgrade Firmware?"
         message="A reboot is required to finalise the upgrade process."
-      />
-      <RebootModal
-        isOpen={rebootModalOpened}
-        onClose={() => setRebootModalOpened(false)}
-        onReboot={handleRebootBMC}
-        title="Upgrade Finished!"
-        message={
-          <div className="text-neutral-900 opacity-60 dark:text-neutral-100">
-            <p>To finalize the upgrade, a system reboot is necessary.</p>
-            <p>Would you like to proceed with the reboot now?</p>
-            <p className="mt-4 text-xs italic">
-              The nodes will temporarily lose power until the reboot process is
-              complete.
-            </p>
-          </div>
-        }
-        isPending={isPending}
       />
     </TabView>
   );


### PR DESCRIPTION
Refactored the flashing logic for both `Firmware Upgrade` and `Flash Node` tabs into a global provider & context, allowing it to continue no matter the tab the user is currently at.
The new context handles toasts and the reboot dialog (after `Firmware Upgrade` finishes), allowing it to report the status anywhere.

Also, here are some edge cases I've covered:
- Navigation links for either Flash Node or Firmware Upgrade will now pulse accordingly if a flashing procedure is ongoing to give the user a clue something is going on there.
- The UI will now allow only one Flash procedure at a time, disallowing a behavior where the user could have been running a Flash Node procedure and then attempting to do a Firmware Upgrade simultaneously.

The bundle size is at `1254 KB`. Bumped patch version to `3.1.2`.

Fixes #10

Caveat: Because React unmounts all unused components on navigation changes, I cannot keep the form states across tab changes. The tab will still report the progress for an ongoing flashing procedure, but the file and SHA-256 fields will be lost if the tab changes. If I store the form state in this new context, that would load the file into RAM... It does not sound like a good idea 😄 