### PR TITLE
fix: improve error handling in FlashContext

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bmc-ui",
-    "version": "3.3.1",
+    "version": "3.3.2",
     "private": true,
     "type": "module",
     "scripts": {

--- a/src/contexts/FlashContext.tsx
+++ b/src/contexts/FlashContext.tsx
@@ -1,4 +1,4 @@
-import { type AxiosProgressEvent } from "axios";
+import { type AxiosError, type AxiosProgressEvent } from "axios";
 import { filesize } from "filesize";
 import React, {
   createContext,
@@ -125,11 +125,13 @@ export const FlashProvider: React.FC<FlashProviderProps> = ({ children }) => {
       },
       onError: (error) => {
         setIsUploading(false);
-        const msg = t("firmwareUpgrade.uploadFailed");
-        setStatusMessage(msg);
+        const title = t("firmwareUpgrade.uploadFailed");
+        const errorMessage =
+          ((error as AxiosError).response?.data as string) ?? error.message;
+        setStatusMessage(`${title}: ${errorMessage}`);
         toast({
-          title: msg,
-          description: error.message,
+          title,
+          description: errorMessage,
           variant: "destructive",
         });
       },
@@ -159,11 +161,13 @@ export const FlashProvider: React.FC<FlashProviderProps> = ({ children }) => {
       },
       onError: (error) => {
         setIsUploading(false);
-        const msg = t("flashNode.transferFailed", { nodeId });
-        setStatusMessage(msg);
+        const title = t("flashNode.transferFailed", { nodeId });
+        const errorMessage =
+          ((error as AxiosError).response?.data as string) ?? error.message;
+        setStatusMessage(`${title}: ${errorMessage}`);
         toast({
-          title: msg,
-          description: error.message,
+          title,
+          description: errorMessage,
           variant: "destructive",
         });
       },


### PR DESCRIPTION
For FlashContext, if an error comes from the backend with a defined body, it will be rendered within the UI. This applies to both `Firmware Upgrade` and `Flash Node` since they use pretty much the same logic.

I tested it by unplugging one of my nodes from the board 😜 

<img width="1300" alt="Screenshot 2024-07-29 at 3 24 36 PM" src="https://github.com/user-attachments/assets/85543f78-0031-47b8-b36b-88e3187e4646">


Fixes #17

Bumped patch version up to `3.3.2`