### PR TITLE
refactor: Node Power Confirmation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "bmc-ui",
-    "version": "3.3.5",
+    "version": "3.3.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "bmc-ui",
-            "version": "3.3.5",
+            "version": "3.3.6",
             "dependencies": {
                 "@fontsource/inter": "^5.1.1",
                 "@radix-ui/react-avatar": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bmc-ui",
-    "version": "3.3.5",
+    "version": "3.3.6",
     "private": true,
     "type": "module",
     "scripts": {

--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -26,7 +26,7 @@ interface ConfirmationModalProps {
   onClose: () => void;
   onConfirm: () => void;
   title: string;
-  message: string;
+  message: string | React.ReactNode;
 }
 
 export default function ConfirmationModal({
@@ -39,13 +39,22 @@ export default function ConfirmationModal({
   const { t } = useTranslation();
   const isDesktop = useMediaQuery("(min-width: 768px)");
 
+  const messageContent =
+    typeof message === "string" ? (
+      <DialogDescription>{message}</DialogDescription>
+    ) : (
+      <div className="text-sm text-neutral-500 dark:text-neutral-400">
+        {message}
+      </div>
+    );
+
   if (isDesktop) {
     return (
       <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
         <DialogContent className={cn("modal-rounded", "p-6")}>
           <DialogHeader>
             <DialogTitle className="mb-4">{title}</DialogTitle>
-            <DialogDescription>{message}</DialogDescription>
+            {messageContent}
           </DialogHeader>
           <DialogFooter className="mt-2">
             <Button type="button" variant="bw" onClick={onClose}>
@@ -65,7 +74,13 @@ export default function ConfirmationModal({
       <DrawerContent>
         <DrawerHeader className="text-left">
           <DrawerTitle className="mb-4">{title}</DrawerTitle>
-          <DrawerDescription>{message}</DrawerDescription>
+          {typeof message === "string" ? (
+            <DrawerDescription>{message}</DrawerDescription>
+          ) : (
+            <div className="text-sm text-neutral-500 dark:text-neutral-400">
+              {message}
+            </div>
+          )}
         </DrawerHeader>
         <DrawerFooter className="mt-2">
           <DrawerClose asChild>

--- a/src/locale/de.ts
+++ b/src/locale/de.ts
@@ -65,6 +65,15 @@ const translations = {
     nodeRestarted: "Knoten {{nodeId}} wurde neu gestartet.",
     pmError: "Fehler beim Ändern des Knotenstatus.",
     persistSuccess: "Knoteninformationen gespeichert.",
+    powerOffConfirmTitle: "Knoten {{nodeId}} ausschalten?",
+    powerOnConfirmTitle: "Knoten {{nodeId}} einschalten?",
+    resetConfirmTitle: "Knoten {{nodeId}} zurücksetzen?",
+    powerOffConfirmDescription:
+      "Dies wird Knoten {{nodeId}} herunterfahren. Alle laufenden Prozesse werden beendet.",
+    powerOnConfirmDescription: "Dies wird Knoten {{nodeId}} starten.",
+    resetConfirmDescription:
+      "Dies wird Knoten {{nodeId}} zwangsweise neu starten. Nicht gespeicherte Daten gehen verloren.",
+    dontAskAgain: "Bei Knotenstromoperationen nicht mehr nachfragen",
   },
   usb: {
     header: "USB-Route",

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -62,6 +62,15 @@ const translations = {
     nodeRestarted: "Node {{nodeId}} was restarted.",
     pmError: "Error changing node state.",
     persistSuccess: "Nodes information saved.",
+    powerOffConfirmTitle: "Power off Node {{nodeId}}?",
+    powerOnConfirmTitle: "Power on Node {{nodeId}}?",
+    resetConfirmTitle: "Reset Node {{nodeId}}?",
+    powerOffConfirmDescription:
+      "This will shut down Node {{nodeId}}. Any running processes will be terminated.",
+    powerOnConfirmDescription: "This will start up Node {{nodeId}}.",
+    resetConfirmDescription:
+      "This will forcefully restart Node {{nodeId}}. Any unsaved data will be lost.",
+    dontAskAgain: "Don't ask again for node power operations",
   },
   usb: {
     header: "USB route",

--- a/src/locale/es.ts
+++ b/src/locale/es.ts
@@ -64,6 +64,15 @@ const translations = {
     nodeRestarted: "El nodo {{nodeId}} se reinició.",
     pmError: "Error al cambiar el estado del nodo.",
     persistSuccess: "Información de nodos guardada.",
+    powerOffConfirmTitle: "¿Apagar Nodo {{nodeId}}?",
+    powerOnConfirmTitle: "¿Encender Nodo {{nodeId}}?",
+    resetConfirmTitle: "¿Reiniciar Nodo {{nodeId}}?",
+    powerOffConfirmDescription:
+      "Esto apagará el Nodo {{nodeId}}. Todos los procesos en ejecución serán terminados.",
+    powerOnConfirmDescription: "Esto iniciará el Nodo {{nodeId}}.",
+    resetConfirmDescription:
+      "Esto reiniciará forzosamente el Nodo {{nodeId}}. Cualquier dato no guardado se perderá.",
+    dontAskAgain: "No volver a preguntar para operaciones de energía de nodos",
   },
   usb: {
     header: "Ruta USB",

--- a/src/locale/nl.ts
+++ b/src/locale/nl.ts
@@ -64,6 +64,15 @@ const translations = {
     nodeRestarted: "Node {{nodeId}} is opnieuw gestart.",
     pmError: "Fout bij het wijzigen van de nodestatus.",
     persistSuccess: "Node-informatie opgeslagen.",
+    powerOffConfirmTitle: "Node {{nodeId}} uitschakelen?",
+    powerOnConfirmTitle: "Node {{nodeId}} inschakelen?",
+    resetConfirmTitle: "Node {{nodeId}} herstarten?",
+    powerOffConfirmDescription:
+      "Dit zal Node {{nodeId}} afsluiten. Alle lopende processen worden beëindigd.",
+    powerOnConfirmDescription: "Dit zal Node {{nodeId}} opstarten.",
+    resetConfirmDescription:
+      "Dit zal Node {{nodeId}} geforceerd herstarten. Niet-opgeslagen gegevens gaan verloren.",
+    dontAskAgain: "Niet meer vragen voor node-stroomacties",
   },
   usb: {
     header: "USB-route",

--- a/src/locale/pl.ts
+++ b/src/locale/pl.ts
@@ -65,6 +65,15 @@ const translations = {
     nodeRestarted: "Węzeł {{nodeId}} został ponownie uruchomiony.",
     pmError: "Błąd podczas zmiany stanu węzła.",
     persistSuccess: "Informacje o węzłach zostały zapisane.",
+    powerOffConfirmTitle: "Wyłączyć Węzeł {{nodeId}}?",
+    powerOnConfirmTitle: "Włączyć Węzeł {{nodeId}}?",
+    resetConfirmTitle: "Zresetować Węzeł {{nodeId}}?",
+    powerOffConfirmDescription:
+      "To wyłączy Węzeł {{nodeId}}. Wszystkie uruchomione procesy zostaną zakończone.",
+    powerOnConfirmDescription: "To uruchomi Węzeł {{nodeId}}.",
+    resetConfirmDescription:
+      "To wymusi restart Węzła {{nodeId}}. Wszystkie niezapisane dane zostaną utracone.",
+    dontAskAgain: "Nie pytaj ponownie o operacje zasilania węzłów",
   },
   usb: {
     header: "Trasa USB",

--- a/src/locale/zh-Hans.ts
+++ b/src/locale/zh-Hans.ts
@@ -63,6 +63,15 @@ const translations = {
     nodeRestarted: "节点 {{nodeId}} 已重新启动。",
     pmError: "更改节点状态时出错。",
     persistSuccess: "节点信息已保存。",
+    powerOffConfirmTitle: "关闭节点 {{nodeId}}？",
+    powerOnConfirmTitle: "启动节点 {{nodeId}}？",
+    resetConfirmTitle: "重置节点 {{nodeId}}？",
+    powerOffConfirmDescription:
+      "这将关闭节点 {{nodeId}}。所有正在运行的进程都将被终止。",
+    powerOnConfirmDescription: "这将启动节点 {{nodeId}}。",
+    resetConfirmDescription:
+      "这将强制重启节点 {{nodeId}}。任何未保存的数据都将丢失。",
+    dontAskAgain: "不再询问节点电源操作",
   },
   usb: {
     header: "USB 路由",

--- a/src/routes/_tabLayout/nodes.lazy.tsx
+++ b/src/routes/_tabLayout/nodes.lazy.tsx
@@ -3,9 +3,11 @@ import { Power, PowerOff } from "lucide-react";
 import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import ConfirmationModal from "@/components/ConfirmationModal";
 import NodesSkeleton from "@/components/skeletons/nodes";
 import TabView from "@/components/TabView";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { useToast } from "@/hooks/use-toast";
@@ -21,6 +23,8 @@ export const Route = createLazyFileRoute("/_tabLayout/nodes")({
   pendingComponent: NodesSkeleton,
 });
 
+const POWER_CONFIRMATION_KEY = "skipNodeConfirmation";
+
 const NodeRow = (
   props: NodeInfoResponse & {
     nodeId: number;
@@ -30,12 +34,19 @@ const NodeRow = (
   const { t } = useTranslation();
   const { toast } = useToast();
   const [powerOn, setPowerOn] = useState(props.power_on_time !== null);
+  const [showPowerDialog, setShowPowerDialog] = useState(false);
+  const [showResetDialog, setShowResetDialog] = useState(false);
+  const [skipConfirmation, setSkipConfirmation] = useState(
+    localStorage.getItem(POWER_CONFIRMATION_KEY) === "true"
+  );
+  const [tempSkipConfirmation, setTempSkipConfirmation] = useState(false);
+
   const { mutate: mutatePowerNode, isPending: isPendingPower } =
     usePowerNodeMutation();
   const { mutate: mutateResetNode, isPending: isPendingReset } =
     useResetNodeMutation();
 
-  const handlePowerNode = () => {
+  const togglePower = () => {
     mutatePowerNode({ nodeId: props.nodeId, powerOn: !powerOn });
     setPowerOn(!powerOn);
     toast({
@@ -44,15 +55,47 @@ const NodeRow = (
         ? t("nodes.nodeOff", { nodeId: props.nodeId })
         : t("nodes.nodeOn", { nodeId: props.nodeId }),
     });
+    setShowPowerDialog(false);
+
+    // Only update localStorage if the checkbox was checked
+    if (tempSkipConfirmation) {
+      localStorage.setItem(POWER_CONFIRMATION_KEY, "true");
+      setSkipConfirmation(true);
+    }
   };
 
-  const handleResetNode = () => {
+  const handlePowerClick = () => {
+    if (skipConfirmation) {
+      togglePower();
+    } else {
+      setTempSkipConfirmation(false); // Reset temporary state
+      setShowPowerDialog(true);
+    }
+  };
+
+  const handleResetClick = () => {
+    if (skipConfirmation) {
+      resetNode();
+    } else {
+      setTempSkipConfirmation(false); // Reset temporary state
+      setShowResetDialog(true);
+    }
+  };
+
+  const resetNode = () => {
+    setShowResetDialog(false);
     mutateResetNode(props.nodeId - 1, {
       onSuccess: () => {
         toast({
           title: t("nodes.powerManagement"),
           description: t("nodes.nodeRestarted", { nodeId: props.nodeId }),
         });
+
+        // Only update localStorage if the checkbox was checked
+        if (tempSkipConfirmation) {
+          localStorage.setItem(POWER_CONFIRMATION_KEY, "true");
+          setSkipConfirmation(true);
+        }
       },
       onError: (e) => {
         toast({
@@ -64,55 +107,124 @@ const NodeRow = (
     });
   };
 
+  const ConfirmationCheckbox = () => (
+    <div className="flex items-center space-x-2 pt-4">
+      <Checkbox
+        id="skipConfirmation"
+        checked={tempSkipConfirmation}
+        onCheckedChange={(checked) =>
+          setTempSkipConfirmation(checked as boolean)
+        }
+      />
+      <label
+        htmlFor="skipConfirmation"
+        className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+      >
+        {t("nodes.dontAskAgain")}
+      </label>
+    </div>
+  );
+
+  const handleCloseDialog = () => {
+    setShowPowerDialog(false);
+    setShowResetDialog(false);
+    setTempSkipConfirmation(false);
+  };
+
   return (
-    <div className="border-b border-neutral-200 py-4 last:border-none dark:border-neutral-700">
-      <div className="flex flex-col gap-4 md:flex-row">
-        <div className="flex items-center gap-4">
-          <Switch
-            name={`node-${props.nodeId}-power`}
-            aria-label={t("nodes.ariaNodePowerToggle", {
-              nodeId: props.nodeId,
-            })}
-            disabled={!props.editMode || isPendingPower}
-            checked={powerOn}
-            onCheckedChange={handlePowerNode}
-            onIcon={<Power size={16} />}
-            offIcon={<PowerOff size={16} />}
-          />
-          <Button
-            type="button"
-            variant="destructive"
-            onClick={handleResetNode}
-            disabled={props.power_on_time === null || isPendingReset}
-            isLoading={isPendingReset}
-          >
-            {t("nodes.restartButton")}
-          </Button>
-        </div>
-        <div className="flex flex-1 flex-wrap gap-4">
-          <Input
-            type="text"
-            name={`node-${props.nodeId}-name`}
-            label={t("nodes.nodeName")}
-            defaultValue={
-              props.name ?? t("nodes.node", { nodeId: props.nodeId })
-            }
-            disabled={!props.editMode}
-            className="flex-1"
-          />
-          <Input
-            type="text"
-            name={`node-${props.nodeId}-module-name`}
-            label={t("nodes.moduleName")}
-            defaultValue={
-              props.module_name ?? t("nodes.module", { moduleId: props.nodeId })
-            }
-            disabled={!props.editMode}
-            className="flex-1"
-          />
+    <>
+      <div className="border-b border-neutral-200 py-4 last:border-none dark:border-neutral-700">
+        <div className="flex flex-col gap-4 md:flex-row">
+          <div className="flex items-center gap-4">
+            <Switch
+              name={`node-${props.nodeId}-power`}
+              aria-label={t("nodes.ariaNodePowerToggle", {
+                nodeId: props.nodeId,
+              })}
+              disabled={isPendingPower}
+              checked={powerOn}
+              onCheckedChange={handlePowerClick}
+              onIcon={<Power size={16} />}
+              offIcon={<PowerOff size={16} />}
+            />
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={handleResetClick}
+              disabled={props.power_on_time === null || isPendingReset}
+              isLoading={isPendingReset}
+            >
+              {t("nodes.restartButton")}
+            </Button>
+          </div>
+          <div className="flex flex-1 flex-wrap gap-4">
+            <Input
+              type="text"
+              name={`node-${props.nodeId}-name`}
+              label={t("nodes.nodeName")}
+              defaultValue={
+                props.name ?? t("nodes.node", { nodeId: props.nodeId })
+              }
+              disabled={!props.editMode}
+              className="flex-1"
+            />
+            <Input
+              type="text"
+              name={`node-${props.nodeId}-module-name`}
+              label={t("nodes.moduleName")}
+              defaultValue={
+                props.module_name ??
+                t("nodes.module", { moduleId: props.nodeId })
+              }
+              disabled={!props.editMode}
+              className="flex-1"
+            />
+          </div>
         </div>
       </div>
-    </div>
+
+      <ConfirmationModal
+        isOpen={showPowerDialog}
+        onClose={handleCloseDialog}
+        title={t(
+          powerOn ? "nodes.powerOffConfirmTitle" : "nodes.powerOnConfirmTitle",
+          {
+            nodeId: props.nodeId,
+          }
+        )}
+        message={
+          <>
+            <p>
+              {t(
+                powerOn
+                  ? "nodes.powerOffConfirmDescription"
+                  : "nodes.powerOnConfirmDescription",
+                {
+                  nodeId: props.nodeId,
+                }
+              )}
+            </p>
+            <ConfirmationCheckbox />
+          </>
+        }
+        onConfirm={togglePower}
+      />
+
+      <ConfirmationModal
+        isOpen={showResetDialog}
+        onClose={handleCloseDialog}
+        title={t("nodes.resetConfirmTitle", { nodeId: props.nodeId })}
+        message={
+          <>
+            <p>
+              {t("nodes.resetConfirmDescription", { nodeId: props.nodeId })}
+            </p>
+            <ConfirmationCheckbox />
+          </>
+        }
+        onConfirm={resetNode}
+      />
+    </>
   );
 };
 


### PR DESCRIPTION
Hey! Here's a new implementation for handling the node power operations (on/off/restart).

This aims to:
- Allow the On/Off and Restart button to operate without being in `Edit Mode`.
- To display a confirmation dialog by default.
- Allow the user to choose to not display the confirmation dialog if desired.

Fixes #22 
Fixes #24

Powering on a node (similar dialog for powering off):
<img width="1222" alt="Screenshot 2025-01-02 at 10 43 13 AM" src="https://github.com/user-attachments/assets/b2334c8e-c188-473a-9c6d-7a45714132d1" />

Restarting a node:
<img width="1200" alt="Screenshot 2025-01-02 at 10 43 51 AM" src="https://github.com/user-attachments/assets/f2a4354e-4adc-4240-b5f7-efb022fb8be2" />

If the checkbox is checked, the dialog would not appear in subsequent operations. Note that the users' preference is stored in the browser.


I didn't really considered this as much of a "new feature" so I just bumped the patch version. Let me know what you think @svenrademakers !