### PR TITLE
feat: Add network bonding configuration page

### DIFF
--- a/src/components/navigation-links.tsx
+++ b/src/components/navigation-links.tsx
@@ -10,6 +10,7 @@ const navigationLinks = [
   { to: "/info", label: "navigation.info" },
   { to: "/nodes", label: "navigation.nodes" },
   { to: "/usb", label: "navigation.usb" },
+  { to: "/network", label: "navigation.network" },
   { to: "/firmware-upgrade", label: "navigation.firmwareUpgrade" },
   { to: "/flash-node", label: "navigation.flashNode" },
   { to: "/about", label: "navigation.about" },

--- a/src/components/skeletons/network.tsx
+++ b/src/components/skeletons/network.tsx
@@ -1,0 +1,36 @@
+import TabView from "../TabView";
+
+export default function NetworkSkeleton() {
+  return (
+    <TabView>
+      <div className="flex flex-col gap-8">
+        <div>
+          <div className="mb-8 h-7 w-48 animate-pulse bg-neutral-200 dark:bg-neutral-700"></div>
+          <div className="mb-6 h-5 w-96 animate-pulse bg-neutral-200 dark:bg-neutral-700"></div>
+          <div className="space-y-6">
+            <div className="flex items-center justify-between">
+              <div className="h-5 w-32 animate-pulse bg-neutral-200 dark:bg-neutral-700"></div>
+              <div className="h-6 w-12 animate-pulse rounded-full bg-neutral-200 dark:bg-neutral-700"></div>
+            </div>
+            <div className="space-y-2">
+              <div className="h-5 w-28 animate-pulse bg-neutral-200 dark:bg-neutral-700"></div>
+              <div className="h-10 w-full animate-pulse bg-neutral-200 dark:bg-neutral-700"></div>
+              <div className="h-4 w-72 animate-pulse bg-neutral-200 dark:bg-neutral-700"></div>
+            </div>
+          </div>
+          <div className="mt-6">
+            <div className="h-9 w-32 animate-pulse rounded-full bg-neutral-200 dark:bg-neutral-700"></div>
+          </div>
+        </div>
+        <div>
+          <div className="mb-6 h-7 w-24 animate-pulse bg-neutral-200 dark:bg-neutral-700"></div>
+          <div className="space-y-4">
+            <div className="h-6 w-full animate-pulse bg-neutral-200 dark:bg-neutral-700"></div>
+            <div className="h-6 w-full animate-pulse bg-neutral-200 dark:bg-neutral-700"></div>
+            <div className="h-6 w-full animate-pulse bg-neutral-200 dark:bg-neutral-700"></div>
+          </div>
+        </div>
+      </div>
+    </TabView>
+  );
+}

--- a/src/lib/api/get.ts
+++ b/src/lib/api/get.ts
@@ -241,12 +241,13 @@ export function useNetworkConfigQuery() {
   return useSuspenseQuery({
     queryKey: ["networkConfig"],
     queryFn: async () => {
-      const response = await api.get<NetworkConfigResponse>("/api", {
+      const response = await api.get<APIResponse<NetworkConfigResponse>>("/bmc", {
         params: {
-          cmd: "network_config",
+          opt: "get",
+          type: "network_config",
         },
       });
-      return response.data;
+      return response.data.response[0].result;
     },
   });
 }

--- a/src/lib/api/get.ts
+++ b/src/lib/api/get.ts
@@ -226,3 +226,27 @@ export function useUSBNode1Query() {
     },
   });
 }
+
+export interface NetworkConfigResponse {
+  bonding_enabled: boolean;
+  bonding_mode: string;
+  bonding_active: boolean;
+  slaves: string[];
+  miimon: number;
+}
+
+export function useNetworkConfigQuery() {
+  const api = useAxiosWithAuth();
+
+  return useSuspenseQuery({
+    queryKey: ["networkConfig"],
+    queryFn: async () => {
+      const response = await api.get<NetworkConfigResponse>("/api", {
+        params: {
+          cmd: "network_config",
+        },
+      });
+      return response.data;
+    },
+  });
+}

--- a/src/lib/api/set.ts
+++ b/src/lib/api/set.ts
@@ -241,15 +241,16 @@ export function useNetworkConfigMutation() {
   return useMutation({
     mutationKey: ["networkConfigMutation"],
     mutationFn: async (variables: NetworkConfigPayload) => {
-      const response = await api.get<{ success: boolean }>("/api", {
+      const response = await api.get<APIResponse<string>>("/bmc", {
         params: {
-          cmd: "network_config",
+          opt: "set",
+          type: "network_config",
           enabled: variables.enabled ? "1" : "0",
           mode: variables.mode,
           apply: variables.apply ? "1" : "0",
         },
       });
-      return response.data;
+      return response.data.response[0].result;
     },
     onSettled: () => {
       void queryClient.invalidateQueries({ queryKey: ["networkConfig"] });

--- a/src/lib/api/set.ts
+++ b/src/lib/api/set.ts
@@ -227,3 +227,33 @@ export function useUSBNode1Mutation() {
     },
   });
 }
+
+export interface NetworkConfigPayload {
+  enabled: boolean;
+  mode: string;
+  apply?: boolean;
+}
+
+export function useNetworkConfigMutation() {
+  const api = useAxiosWithAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: ["networkConfigMutation"],
+    mutationFn: async (variables: NetworkConfigPayload) => {
+      const response = await api.get<{ success: boolean }>("/api", {
+        params: {
+          cmd: "network_config",
+          enabled: variables.enabled ? "1" : "0",
+          mode: variables.mode,
+          apply: variables.apply ? "1" : "0",
+        },
+      });
+      return response.data;
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ["networkConfig"] });
+      void queryClient.invalidateQueries({ queryKey: ["infoTabData"] });
+    },
+  });
+}

--- a/src/locale/de.ts
+++ b/src/locale/de.ts
@@ -5,6 +5,7 @@ const translations = {
     info: "Info",
     nodes: "Knoten",
     usb: "USB",
+    network: "Netzwerk",
     firmwareUpgrade: "Firmware-Upgrade",
     flashNode: "Knoten flashen",
     about: "Über",

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -3,6 +3,7 @@ const translations = {
     info: "Info",
     nodes: "Nodes",
     usb: "USB",
+    network: "Network",
     firmwareUpgrade: "Firmware Upgrade",
     flashNode: "Flash Node",
     about: "About",
@@ -148,6 +149,46 @@ const translations = {
     buildrootRelease: "Buildroot release",
     apiVersion: "API version",
     bmcUI: "BMC UI",
+  },
+  network: {
+    header: "Link Aggregation (Bonding)",
+    description:
+      "Bond the two Ethernet ports (ge0 and ge1) together for increased bandwidth or redundancy.",
+    enabled: "Bonding Enabled",
+    mode: "Bonding Mode",
+    status: "Status",
+    statusActive: "Active",
+    statusInactive: "Inactive",
+    slaves: "Slave Interfaces",
+    applyButton: "Apply Changes",
+    applySuccess: "Network configuration applied successfully.",
+    applyFailed: "Failed to apply network configuration.",
+    modes: {
+      "active-backup": "Active-Backup (Failover)",
+      "balance-rr": "Balance Round-Robin",
+      "balance-xor": "Balance XOR",
+      broadcast: "Broadcast",
+      "802.3ad": "802.3ad LACP",
+      "balance-tlb": "Balance TLB",
+      "balance-alb": "Balance ALB",
+    },
+    modeDescriptions: {
+      "active-backup":
+        "Only one slave is active. Provides fault tolerance without switch configuration.",
+      "balance-rr":
+        "Round-robin transmit. Requires switch aggregate/trunk configuration.",
+      "balance-xor":
+        "XOR hash based transmit. Requires switch aggregate/trunk configuration.",
+      broadcast: "All slaves transmit all packets. For special use cases.",
+      "802.3ad":
+        "IEEE 802.3ad LACP. Requires switch LACP support. Provides true 2Gbps aggregate bandwidth.",
+      "balance-tlb":
+        "Adaptive transmit load balancing. No switch configuration required.",
+      "balance-alb":
+        "Adaptive load balancing (TX and RX). No switch configuration required.",
+    },
+    switchRequired: "Requires switch configuration",
+    switchNotRequired: "No switch configuration needed",
   },
   ui: {
     cancel: "Cancel",

--- a/src/locale/es.ts
+++ b/src/locale/es.ts
@@ -5,6 +5,7 @@ const translations = {
     info: "Información",
     nodes: "Nodos",
     usb: "USB",
+    network: "Red",
     firmwareUpgrade: "Actualizar Firmware",
     flashNode: "Instalar SO",
     about: "Acerca de",

--- a/src/locale/nl.ts
+++ b/src/locale/nl.ts
@@ -5,6 +5,7 @@ const translations = {
     info: "Info",
     nodes: "Nodes",
     usb: "USB",
+    network: "Netwerk",
     firmwareUpgrade: "Firmware-upgrade",
     flashNode: "Flash-node",
     about: "Over",

--- a/src/locale/pl.ts
+++ b/src/locale/pl.ts
@@ -6,6 +6,7 @@ const translations = {
     info: "Informacje",
     nodes: "Węzły",
     usb: "USB",
+    network: "Siec",
     firmwareUpgrade: "Aktualizacja oprogramowania",
     flashNode: "Flashowanie węzła",
     about: "O programie",

--- a/src/locale/zh-Hans.ts
+++ b/src/locale/zh-Hans.ts
@@ -5,6 +5,7 @@ const translations = {
     info: "信息",
     nodes: "节点",
     usb: "USB",
+    network: "网络",
     firmwareUpgrade: "固件升级",
     flashNode: "刷写节点",
     about: "关于",

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as TabLayoutRouteImport } from './routes/_tabLayout'
 const IndexLazyRouteImport = createFileRoute('/')()
 const TabLayoutUsbLazyRouteImport = createFileRoute('/_tabLayout/usb')()
 const TabLayoutNodesLazyRouteImport = createFileRoute('/_tabLayout/nodes')()
+const TabLayoutNetworkLazyRouteImport = createFileRoute('/_tabLayout/network')()
 const TabLayoutInfoLazyRouteImport = createFileRoute('/_tabLayout/info')()
 const TabLayoutFlashNodeLazyRouteImport = createFileRoute(
   '/_tabLayout/flash-node',
@@ -53,6 +54,13 @@ const TabLayoutNodesLazyRoute = TabLayoutNodesLazyRouteImport.update({
   getParentRoute: () => TabLayoutRoute,
 } as any).lazy(() =>
   import('./routes/_tabLayout/nodes.lazy').then((d) => d.Route),
+)
+const TabLayoutNetworkLazyRoute = TabLayoutNetworkLazyRouteImport.update({
+  id: '/network',
+  path: '/network',
+  getParentRoute: () => TabLayoutRoute,
+} as any).lazy(() =>
+  import('./routes/_tabLayout/network.lazy').then((d) => d.Route),
 )
 const TabLayoutInfoLazyRoute = TabLayoutInfoLazyRouteImport.update({
   id: '/info',
@@ -91,6 +99,7 @@ export interface FileRoutesByFullPath {
   '/firmware-upgrade': typeof TabLayoutFirmwareUpgradeLazyRoute
   '/flash-node': typeof TabLayoutFlashNodeLazyRoute
   '/info': typeof TabLayoutInfoLazyRoute
+  '/network': typeof TabLayoutNetworkLazyRoute
   '/nodes': typeof TabLayoutNodesLazyRoute
   '/usb': typeof TabLayoutUsbLazyRoute
 }
@@ -101,6 +110,7 @@ export interface FileRoutesByTo {
   '/firmware-upgrade': typeof TabLayoutFirmwareUpgradeLazyRoute
   '/flash-node': typeof TabLayoutFlashNodeLazyRoute
   '/info': typeof TabLayoutInfoLazyRoute
+  '/network': typeof TabLayoutNetworkLazyRoute
   '/nodes': typeof TabLayoutNodesLazyRoute
   '/usb': typeof TabLayoutUsbLazyRoute
 }
@@ -113,6 +123,7 @@ export interface FileRoutesById {
   '/_tabLayout/firmware-upgrade': typeof TabLayoutFirmwareUpgradeLazyRoute
   '/_tabLayout/flash-node': typeof TabLayoutFlashNodeLazyRoute
   '/_tabLayout/info': typeof TabLayoutInfoLazyRoute
+  '/_tabLayout/network': typeof TabLayoutNetworkLazyRoute
   '/_tabLayout/nodes': typeof TabLayoutNodesLazyRoute
   '/_tabLayout/usb': typeof TabLayoutUsbLazyRoute
 }
@@ -125,6 +136,7 @@ export interface FileRouteTypes {
     | '/firmware-upgrade'
     | '/flash-node'
     | '/info'
+    | '/network'
     | '/nodes'
     | '/usb'
   fileRoutesByTo: FileRoutesByTo
@@ -135,6 +147,7 @@ export interface FileRouteTypes {
     | '/firmware-upgrade'
     | '/flash-node'
     | '/info'
+    | '/network'
     | '/nodes'
     | '/usb'
   id:
@@ -146,6 +159,7 @@ export interface FileRouteTypes {
     | '/_tabLayout/firmware-upgrade'
     | '/_tabLayout/flash-node'
     | '/_tabLayout/info'
+    | '/_tabLayout/network'
     | '/_tabLayout/nodes'
     | '/_tabLayout/usb'
   fileRoutesById: FileRoutesById
@@ -193,6 +207,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof TabLayoutNodesLazyRouteImport
       parentRoute: typeof TabLayoutRoute
     }
+    '/_tabLayout/network': {
+      id: '/_tabLayout/network'
+      path: '/network'
+      fullPath: '/network'
+      preLoaderRoute: typeof TabLayoutNetworkLazyRouteImport
+      parentRoute: typeof TabLayoutRoute
+    }
     '/_tabLayout/info': {
       id: '/_tabLayout/info'
       path: '/info'
@@ -229,6 +250,7 @@ interface TabLayoutRouteChildren {
   TabLayoutFirmwareUpgradeLazyRoute: typeof TabLayoutFirmwareUpgradeLazyRoute
   TabLayoutFlashNodeLazyRoute: typeof TabLayoutFlashNodeLazyRoute
   TabLayoutInfoLazyRoute: typeof TabLayoutInfoLazyRoute
+  TabLayoutNetworkLazyRoute: typeof TabLayoutNetworkLazyRoute
   TabLayoutNodesLazyRoute: typeof TabLayoutNodesLazyRoute
   TabLayoutUsbLazyRoute: typeof TabLayoutUsbLazyRoute
 }
@@ -238,6 +260,7 @@ const TabLayoutRouteChildren: TabLayoutRouteChildren = {
   TabLayoutFirmwareUpgradeLazyRoute: TabLayoutFirmwareUpgradeLazyRoute,
   TabLayoutFlashNodeLazyRoute: TabLayoutFlashNodeLazyRoute,
   TabLayoutInfoLazyRoute: TabLayoutInfoLazyRoute,
+  TabLayoutNetworkLazyRoute: TabLayoutNetworkLazyRoute,
   TabLayoutNodesLazyRoute: TabLayoutNodesLazyRoute,
   TabLayoutUsbLazyRoute: TabLayoutUsbLazyRoute,
 }

--- a/src/routes/_tabLayout/network.lazy.tsx
+++ b/src/routes/_tabLayout/network.lazy.tsx
@@ -1,0 +1,164 @@
+import { createLazyFileRoute } from "@tanstack/react-router";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import NetworkSkeleton from "@/components/skeletons/network";
+import TableItem from "@/components/TableItem";
+import TabView from "@/components/TabView";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { useToast } from "@/hooks/use-toast";
+import { useNetworkConfigQuery } from "@/lib/api/get";
+import { useNetworkConfigMutation } from "@/lib/api/set";
+
+const BONDING_MODES = [
+  { value: "active-backup", requiresSwitch: false },
+  { value: "balance-rr", requiresSwitch: true },
+  { value: "balance-xor", requiresSwitch: true },
+  { value: "broadcast", requiresSwitch: false },
+  { value: "802.3ad", requiresSwitch: true },
+  { value: "balance-tlb", requiresSwitch: false },
+  { value: "balance-alb", requiresSwitch: false },
+] as const;
+
+export const Route = createLazyFileRoute("/_tabLayout/network")({
+  component: Network,
+  errorComponent: () => <div>Error loading Network settings</div>,
+  pendingComponent: NetworkSkeleton,
+});
+
+function Network() {
+  const { t } = useTranslation();
+  const { toast } = useToast();
+  const { data } = useNetworkConfigQuery();
+  const { mutate: mutateNetworkConfig, isPending } = useNetworkConfigMutation();
+
+  const [enabled, setEnabled] = useState(data.bonding_enabled);
+  const [mode, setMode] = useState(data.bonding_mode);
+
+  const hasChanges = enabled !== data.bonding_enabled || mode !== data.bonding_mode;
+
+  const selectedMode = BONDING_MODES.find((m) => m.value === mode);
+
+  const handleApply = () => {
+    mutateNetworkConfig(
+      { enabled, mode, apply: true },
+      {
+        onSuccess: () => {
+          toast({
+            title: t("network.header"),
+            description: t("network.applySuccess"),
+          });
+        },
+        onError: (e) => {
+          toast({
+            title: t("network.header"),
+            description: e.message || t("network.applyFailed"),
+            variant: "destructive",
+          });
+        },
+      }
+    );
+  };
+
+  return (
+    <TabView>
+      <div>
+        <div className="mb-6 text-lg font-bold">{t("network.header")}</div>
+        <p className="mb-6 text-sm text-neutral-600 dark:text-neutral-400">
+          {t("network.description")}
+        </p>
+
+        <div className="space-y-6">
+          {/* Bonding Enable Toggle */}
+          <div className="flex items-center justify-between">
+            <div className="font-semibold">{t("network.enabled")}</div>
+            <Switch
+              checked={enabled}
+              onCheckedChange={setEnabled}
+              aria-label={t("network.enabled")}
+            />
+          </div>
+
+          {/* Bonding Mode Select */}
+          <div className="space-y-2">
+            <div className="font-semibold">{t("network.mode")}</div>
+            <Select value={mode} onValueChange={setMode} disabled={!enabled}>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder={t("ui.selectPlaceholder")} />
+              </SelectTrigger>
+              <SelectContent>
+                {BONDING_MODES.map((bondMode) => (
+                  <SelectItem key={bondMode.value} value={bondMode.value}>
+                    {t(`network.modes.${bondMode.value}`)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {selectedMode && (
+              <p className="text-sm text-neutral-500 dark:text-neutral-400">
+                {t(`network.modeDescriptions.${mode}`)}
+              </p>
+            )}
+            {selectedMode && (
+              <p
+                className={`text-xs ${selectedMode.requiresSwitch ? "text-amber-600 dark:text-amber-400" : "text-green-600 dark:text-green-400"}`}
+              >
+                {selectedMode.requiresSwitch
+                  ? t("network.switchRequired")
+                  : t("network.switchNotRequired")}
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* Apply Button */}
+        <div className="mt-6">
+          <Button
+            type="button"
+            onClick={handleApply}
+            isLoading={isPending}
+            disabled={isPending || !hasChanges}
+          >
+            {t("network.applyButton")}
+          </Button>
+        </div>
+      </div>
+
+      {/* Current Status */}
+      <div>
+        <div className="mb-6 text-lg font-bold">{t("network.status")}</div>
+        <div className="space-y-4">
+          <dl>
+            <TableItem term={t("network.status")}>
+              <span
+                className={
+                  data.bonding_active
+                    ? "text-green-600 dark:text-green-400"
+                    : "text-neutral-500"
+                }
+              >
+                {data.bonding_active
+                  ? t("network.statusActive")
+                  : t("network.statusInactive")}
+              </span>
+            </TableItem>
+            <TableItem term={t("network.mode")}>
+              {t(`network.modes.${data.bonding_mode}`)}
+            </TableItem>
+            <TableItem term={t("network.slaves")}>
+              {data.slaves.length > 0 ? data.slaves.join(", ") : "—"}
+            </TableItem>
+          </dl>
+        </div>
+      </div>
+    </TabView>
+  );
+}

--- a/src/routes/_tabLayout/network.lazy.tsx
+++ b/src/routes/_tabLayout/network.lazy.tsx
@@ -91,7 +91,7 @@ function Network() {
           <div className="space-y-2">
             <div className="font-semibold">{t("network.mode")}</div>
             <Select value={mode} onValueChange={setMode} disabled={!enabled}>
-              <SelectTrigger className="w-full">
+              <SelectTrigger className="w-full" label={t("network.mode")}>
                 <SelectValue placeholder={t("ui.selectPlaceholder")} />
               </SelectTrigger>
               <SelectContent>


### PR DESCRIPTION
## Summary
Add a Network Settings page to configure NIC link aggregation (bonding) on the Turing Pi BMC.

## Changes

### New Files
- `src/routes/_tabLayout/network.lazy.tsx` - Network bonding configuration page
- `src/components/skeletons/network.tsx` - Loading skeleton for network page

### Modified Files
- `src/components/navigation-links.tsx` - Added Network link to navigation
- `src/lib/api/get.ts` - Added `useNetworkConfigQuery` hook
- `src/lib/api/set.ts` - Added `useNetworkConfigMutation` hook
- `src/locale/en.ts` - Added network-related translations
- Other locale files - Added network navigation key

## Features
- Toggle to enable/disable bonding
- Dropdown to select bonding mode with descriptions
- Status display showing bonding state and slave interfaces
- Visual indicators for modes that require switch configuration

## API Endpoints
- `GET /api/bmc?opt=get&type=network_config`
- `GET /api/bmc?opt=set&type=network_config&enabled=1&mode=802.3ad&apply=1`

## Related PRs
- BMC-Firmware: https://github.com/turing-machines/BMC-Firmware/pull/254

🤖 Generated with [Claude Code](https://claude.com/claude-code)